### PR TITLE
PR Guardrails: go-live (pin @main) + trigger on converted_to_draft

### DIFF
--- a/.github/workflows/pr-guardrails.yml
+++ b/.github/workflows/pr-guardrails.yml
@@ -7,7 +7,7 @@ name: PR Guardrails
 
 on:
   pull_request_target:
-    types: [opened, reopened, ready_for_review, edited, synchronize]
+    types: [opened, reopened, ready_for_review, converted_to_draft, edited, synchronize]
   check_suite:
     types: [completed]
 


### PR DESCRIPTION
Go-live changes to the generic PR Guardrails trigger:

- **Pin the central pipeline to `@main`** (was `@feature/pr-guardrails`), now that the guardrail pipeline is being merged to `main` in `pimcore/workflows-collection-public` (see pimcore/workflows-collection-public#105).
- **Add `converted_to_draft`** to the `pull_request_target` types, enabling override **retraction**: when a Dev-Team member converts a PR back to draft, the central pipeline removes the `guardrails:override` label.

The workflow stays generic — single `uses:` of the orchestrator + `secrets: inherit`.

⚠️ **Merge order:** merge pimcore/workflows-collection-public#105 first (so `@main` resolves), then merge this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)