### PR TITLE
PR Guardrails: isolate converted_to_draft concurrency group

### DIFF
--- a/.github/workflows/pr-guardrails.yml
+++ b/.github/workflows/pr-guardrails.yml
@@ -16,7 +16,9 @@ concurrency:
   # no PR number, so use the PR from the check_suite payload (present for
   # same-repo PRs) to share the same lock; fall back to the commit SHA for fork
   # PRs, then to run_id so the key is never empty.
-  group: pr-guardrails-${{ github.event.pull_request.number || github.event.check_suite.pull_requests[0].number || github.event.check_suite.head_sha || github.run_id }}
+  # A guardrail can convert the PR to draft, which fires converted_to_draft;
+  # give that its own group so it does not cancel the run still acting on the PR.
+  group: pr-guardrails-${{ github.event.action == 'converted_to_draft' && 'retract-' || '' }}${{ github.event.pull_request.number || github.event.check_suite.pull_requests[0].number || github.event.check_suite.head_sha || github.run_id }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
When a guardrail fails it converts the PR to draft. With `converted_to_draft` in the trigger (added for override retraction), that draft-conversion fires a **second** run which — sharing the per-PR concurrency group with `cancel-in-progress: true` — cancels the run that just acted on the PR. That's why a single *Ready for review* click produced one `cancelled` run + one redundant run.

Fix: give `converted_to_draft` events their own concurrency group (`pr-guardrails-retract-<n>`) so they no longer cancel the main per-PR run.

Pairs with the central change (pimcore/workflows-collection-public, commit `c68208e`) that stops the guard service account's own draft-conversions from being treated as a member override-retraction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)