### PR TITLE
PR Guardrails: pin central pipeline to @main

### DIFF
--- a/.github/workflows/pr-guardrails.yml
+++ b/.github/workflows/pr-guardrails.yml
@@ -25,5 +25,5 @@ jobs:
   guardrails:
     # During testing this points at the test branch (@feature/pr-guardrails);
     # flip to @main (or a @vX tag) once the central pipeline is validated.
-    uses: pimcore/workflows-collection-public/.github/workflows/parent-pr-guardrails.yml@feature/pr-guardrails
+    uses: pimcore/workflows-collection-public/.github/workflows/parent-pr-guardrails.yml@main
     secrets: inherit


### PR DESCRIPTION
Flip the trigger's `uses:` from `@feature/pr-guardrails` to `@main`, now that the guardrail pipeline is going live on `main` in `pimcore/workflows-collection-public` (PR #105).

⚠️ **Merge order:** merge pimcore/workflows-collection-public#105 **first** (so `@main` contains the pipeline + `lib.js`), then merge this PR. Merging this before #105 would make the trigger reference a non-existent `@main` workflow.

After both are merged, future guardrail logic changes are just edit + push to `main` in the collection — no ref changes here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)